### PR TITLE
fix: handle email addresses with a + in them

### DIFF
--- a/src/app/customers/[did]/page.tsx
+++ b/src/app/customers/[did]/page.tsx
@@ -8,6 +8,7 @@ import { useCustomer } from "@/hooks/customer"
 import { useRateLimitActions } from "@/hooks/rate-limit"
 import { SimpleError } from "@/components/error"
 import { Loader } from "@/components/brand"
+import { EmailAddress } from "@web3-storage/did-mailto/dist/src/types"
 
 export const runtime = 'edge'
 
@@ -18,8 +19,15 @@ function domainFromEmail (email: string) {
 
 function mailtoDidFromUrlComponent (urlComponent: string) {
   try {
-    return DidMailto.fromString(decodeURIComponent(urlComponent))
-  } catch {
+    // This is surprisingly tricky - any URL-encoded characters in the email address will
+    // be decoded by decodeURIComponent, but we want to preserve the URL-encoding in the email
+    // address. To solve this, we pull the email address out after parsing the DID and re-encode it
+    // before recreating the DID in the return value.
+    const decodedMailtoDID = DidMailto.fromString(decodeURIComponent(urlComponent))
+    const urlEncodedEmail = encodeURI(DidMailto.toEmail(decodedMailtoDID))
+    return DidMailto.fromEmail(urlEncodedEmail as EmailAddress)
+  } catch (e) {
+    console.log("failed to parse mailto DID from URL", urlComponent, e)
     return undefined
   }
 }

--- a/src/app/customers/[did]/page.tsx
+++ b/src/app/customers/[did]/page.tsx
@@ -38,7 +38,7 @@ export default function Customer ({ params: { did: encodedDid } }: { params: { d
       <div className='flex flex-col items-center'>
         <h2 className='text-2xl mb-4'>Customer {did}</h2>
         {isLoading && <Loader />}
-        {error && <SimpleError>{error.toString()}</SimpleError>}
+        {error && <SimpleError>{error.message?.toString() || `Error loading ${did}`}</SimpleError>}
         {customer && (
           <div className='flex flex-col items-center'>
             <div className='flex flex-row space-x-2 mt-4 mb-2'>

--- a/src/app/customers/[did]/page.tsx
+++ b/src/app/customers/[did]/page.tsx
@@ -8,7 +8,6 @@ import { useCustomer } from "@/hooks/customer"
 import { useRateLimitActions } from "@/hooks/rate-limit"
 import { SimpleError } from "@/components/error"
 import { Loader } from "@/components/brand"
-import { EmailAddress } from "@web3-storage/did-mailto/dist/src/types"
 
 export const runtime = 'edge'
 
@@ -19,15 +18,8 @@ function domainFromEmail (email: string) {
 
 function mailtoDidFromUrlComponent (urlComponent: string) {
   try {
-    // This is surprisingly tricky - any URL-encoded characters in the email address will
-    // be decoded by decodeURIComponent, but we want to preserve the URL-encoding in the email
-    // address. To solve this, we pull the email address out after parsing the DID and re-encode it
-    // before recreating the DID in the return value.
-    const decodedMailtoDID = DidMailto.fromString(decodeURIComponent(urlComponent))
-    const urlEncodedEmail = encodeURI(DidMailto.toEmail(decodedMailtoDID))
-    return DidMailto.fromEmail(urlEncodedEmail as EmailAddress)
-  } catch (e) {
-    console.log("failed to parse mailto DID from URL", urlComponent, e)
+    return DidMailto.fromString(decodeURIComponent(urlComponent))
+  } catch {
     return undefined
   }
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -18,7 +18,7 @@ export default function Root () {
   const goToCustomer = useCallback((e: FormEvent) => {
     e.preventDefault()
     if (customerEmail) {
-      router.push(`/customers/${MailtoDid.fromEmail(customerEmail)}`)
+      router.push(`/customers/${encodeURIComponent(MailtoDid.fromEmail(customerEmail))}`)
     }
   }, [router, customerEmail])
   const [cid, setCid] = useState<string | undefined>()

--- a/src/app/subscriptions/[id]/page.tsx
+++ b/src/app/subscriptions/[id]/page.tsx
@@ -21,8 +21,8 @@ export default function Subscription ({ params: { id: encodedId } }: { params: {
             <tr>
               <td className='font-bold'>Customer</td>
               <td>
-                <Link className='underline text-blue-200' href={`/customers/${subscription.customer}`}>
-                  {subscription.customer}
+                <Link className='underline text-blue-200' href={`/customers/${encodeURIComponent(subscription.customer)}`}>
+                  {decodeURIComponent(subscription.customer)}
                 </Link>
               </td>
             </tr>


### PR DESCRIPTION
they were being decoded because they are coming in through the URL, but the encoding needs to be preserve to interact with our system